### PR TITLE
Added PERSISTED phase

### DIFF
--- a/__tests__/src/services/avatarService.spec.ts
+++ b/__tests__/src/services/avatarService.spec.ts
@@ -33,6 +33,7 @@ describe('services/avatarService/_getNextAvatarId', () => {
 					name: 'player 1',
 					playerId: <UUID>'065a4368-b566-4e5b-95c7-f37e2982dbe5',
 					websocket: <FSMWebSocket>(<unknown>'websocket 1'),
+					ephemeral: {},
 				},
 			];
 			result = _getNextAvatarId(avatarIds, players);
@@ -51,6 +52,7 @@ describe('services/avatarService/_getNextAvatarId', () => {
 					name: 'player 1',
 					playerId: <UUID>'065a4368-b566-4e5b-95c7-f37e2982dbe5',
 					websocket: <FSMWebSocket>(<unknown>'websocket 1'),
+					ephemeral: {},
 				},
 				{
 					status: AwaitingMove,
@@ -58,6 +60,7 @@ describe('services/avatarService/_getNextAvatarId', () => {
 					name: 'player 2',
 					playerId: <UUID>'3d20b5eb-66ce-45ea-90d0-3e211b34548d',
 					websocket: <FSMWebSocket>(<unknown>'websocket 2'),
+					ephemeral: {},
 				},
 			];
 			result = _getNextAvatarId(avatarIds, players);
@@ -76,6 +79,7 @@ describe('services/avatarService/_getNextAvatarId', () => {
 					name: 'player 1',
 					playerId: <UUID>'065a4368-b566-4e5b-95c7-f37e2982dbe5',
 					websocket: <FSMWebSocket>(<unknown>'websocket 1'),
+					ephemeral: {},
 				},
 				{
 					status: AwaitingMove,
@@ -83,6 +87,7 @@ describe('services/avatarService/_getNextAvatarId', () => {
 					name: 'player 2',
 					playerId: <UUID>'3d20b5eb-66ce-45ea-90d0-3e211b34548d',
 					websocket: <FSMWebSocket>(<unknown>'websocket 2'),
+					ephemeral: {},
 				},
 				{
 					status: AwaitingMove,
@@ -90,6 +95,7 @@ describe('services/avatarService/_getNextAvatarId', () => {
 					name: 'player 3',
 					playerId: <UUID>'335cdd56-d005-489f-b15d-f7968ae7eb3c',
 					websocket: <FSMWebSocket>(<unknown>'websocket 3'),
+					ephemeral: {},
 				},
 			];
 			result = _getNextAvatarId(avatarIds, players);
@@ -108,6 +114,7 @@ describe('services/avatarService/_getNextAvatarId', () => {
 					name: 'player 1',
 					playerId: <UUID>'065a4368-b566-4e5b-95c7-f37e2982dbe5',
 					websocket: <FSMWebSocket>(<unknown>'websocket 1'),
+					ephemeral: {},
 				},
 				{
 					status: AwaitingMove,
@@ -115,6 +122,7 @@ describe('services/avatarService/_getNextAvatarId', () => {
 					name: 'player 2',
 					playerId: <UUID>'3d20b5eb-66ce-45ea-90d0-3e211b34548d',
 					websocket: <FSMWebSocket>(<unknown>'websocket 2'),
+					ephemeral: {},
 				},
 				{
 					status: AwaitingMove,
@@ -122,6 +130,7 @@ describe('services/avatarService/_getNextAvatarId', () => {
 					name: 'player 3',
 					playerId: <UUID>'335cdd56-d005-489f-b15d-f7968ae7eb3c',
 					websocket: <FSMWebSocket>(<unknown>'websocket 3'),
+					ephemeral: {},
 				},
 				{
 					status: AwaitingMove,
@@ -129,6 +138,7 @@ describe('services/avatarService/_getNextAvatarId', () => {
 					name: 'player 4',
 					playerId: <UUID>'d807ed4b-d379-4d2f-b31c-13cfb7f0bb0a',
 					websocket: <FSMWebSocket>(<unknown>'websocket 4'),
+					ephemeral: {},
 				},
 			];
 			result = _getNextAvatarId(avatarIds, players);

--- a/__tests__/src/util/player.spec.ts
+++ b/__tests__/src/util/player.spec.ts
@@ -29,6 +29,7 @@ describe('util/player', () => {
 						websocket: <FSMWebSocket>{
 							readyState: WebSocket.OPEN,
 						},
+						ephemeral: {},
 					},
 				];
 				result = getNextPlayerId({
@@ -51,6 +52,7 @@ describe('util/player', () => {
 						websocket: <FSMWebSocket>{
 							readyState: WebSocket.CLOSED,
 						},
+						ephemeral: {},
 					},
 					{
 						status: AwaitingMove,
@@ -60,6 +62,7 @@ describe('util/player', () => {
 						websocket: <FSMWebSocket>{
 							readyState: WebSocket.OPEN,
 						},
+						ephemeral: {},
 					},
 					{
 						status: AwaitingMove,
@@ -69,6 +72,7 @@ describe('util/player', () => {
 						websocket: <FSMWebSocket>{
 							readyState: WebSocket.CLOSED,
 						},
+						ephemeral: {},
 					},
 				];
 				result = getNextPlayerId({
@@ -91,6 +95,7 @@ describe('util/player', () => {
 						websocket: <FSMWebSocket>{
 							readyState: WebSocket.OPEN,
 						},
+						ephemeral: {},
 					},
 					{
 						status: AwaitingMove,
@@ -100,6 +105,7 @@ describe('util/player', () => {
 						websocket: <FSMWebSocket>{
 							readyState: WebSocket.OPEN,
 						},
+						ephemeral: {},
 					},
 					{
 						status: AwaitingMove,
@@ -109,6 +115,7 @@ describe('util/player', () => {
 						websocket: <FSMWebSocket>{
 							readyState: WebSocket.CLOSED,
 						},
+						ephemeral: {},
 					},
 				];
 				result = getNextPlayerId({
@@ -131,6 +138,7 @@ describe('util/player', () => {
 						websocket: <FSMWebSocket>{
 							readyState: WebSocket.CLOSED,
 						},
+						ephemeral: {},
 					},
 					{
 						status: AwaitingMove,
@@ -140,6 +148,7 @@ describe('util/player', () => {
 						websocket: <FSMWebSocket>{
 							readyState: WebSocket.OPEN,
 						},
+						ephemeral: {},
 					},
 					{
 						status: AwaitingMove,
@@ -149,6 +158,7 @@ describe('util/player', () => {
 						websocket: <FSMWebSocket>{
 							readyState: WebSocket.OPEN,
 						},
+						ephemeral: {},
 					},
 				];
 				result = getNextPlayerId({

--- a/db/migrations/20200730130328_create_state_machine_table.js
+++ b/db/migrations/20200730130328_create_state_machine_table.js
@@ -1,10 +1,10 @@
 const upSQL = `
-	CREATE TYPE state AS ENUM ('START', 'PLAYING', 'FINISHED');
+	CREATE TYPE phase AS ENUM ('START', 'PLAYING', 'FINISHED', 'PERSISTED');
 
 	CREATE TABLE fsm_state (
 		id uuid PRIMARY KEY,
 		json jsonb NOT NULL,
-		current_state state NOT NULL,
+		phase phase NOT NULL,
 		created_date timestamp NOT NULL,
 		updated_date timestamp NOT NULL
 	);
@@ -13,7 +13,7 @@ const upSQL = `
 const downSQL = `
 	DROP TABLE fsm_state;
 
-	DROP TYPE state;
+	DROP TYPE phase;
 `;
 
 exports.up = function(knex) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1576,6 +1576,21 @@
       "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.1.tgz",
       "integrity": "sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ=="
     },
+    "async-mutex": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/async-mutex/-/async-mutex-0.2.4.tgz",
+      "integrity": "sha512-fcQKOXUKMQc57JlmjBCHtkKNrfGpHyR7vu18RfuLfeTAf4hK9PgOadPR5cDrBQ682zasrLUhJFe7EKAHJOduDg==",
+      "requires": {
+        "tslib": "^2.0.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.0.tgz",
+          "integrity": "sha512-lTqkx847PI7xEDYJntxZH89L2/aXInsyF2luSafe/+0fHOMjlBNXdH6th7f70qxLDhul7KZK0zC8V5ZIyHl0/g=="
+        }
+      }
+    },
     "asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
 		"@types/ws": "^7.2.5",
 		"@typescript-eslint/eslint-plugin": "^3.6.0",
 		"@typescript-eslint/parser": "^3.6.0",
+		"async-mutex": "^0.2.4",
 		"axios": "^0.19.0",
 		"body-parser": "^1.19.0",
 		"command-line-args": "^5.1.1",

--- a/src/FSM/FSM.ts
+++ b/src/FSM/FSM.ts
@@ -1,11 +1,19 @@
 'use strict';
 
+import WebSocket from 'ws';
 import { getLoggerByFilename } from '../util/logger';
 import { clearIssues, getIssues } from '../services/issueStore';
 import { Machine, interpret, State } from 'xstate';
 import hardCodedIssues from '../../data/issuesSmall.json';
 import { Logger } from 'log4js';
-import { isPlayersTurn, areOtherPlayersDone, isOnlyConnectedPlayer } from './guards';
+import {
+	isPlayersTurn,
+	areOtherPlayersDone,
+	isOnlyConnectedPlayer,
+	noConnectedPlayers,
+	allPlayersConnected,
+	oneOrMoreConnectedPlayers,
+} from './guards';
 import actions from './actions';
 import * as uuid from 'uuid';
 import {
@@ -23,16 +31,17 @@ import {
 	FSMStateConfig,
 	FSMWebSocket,
 } from '../types';
-import util from 'util';
 import * as FSMStateDAO from '../DAO/FSMState';
 import safeJsonStringify from 'safe-json-stringify';
 import { sendEvent } from '../util/websocket';
 import { cloneDeep } from 'lodash/fp';
+import { Mutex, withTimeout } from 'async-mutex';
+import { getPhase } from '../util/state';
 
 const log: Logger = getLoggerByFilename(__filename);
-const setTimeoutAsync = util.promisify(setTimeout);
 
 const FSMServices: { [key: string]: FSM } = {};
+const mutexes: { [key: string]: Mutex } = {};
 
 const createMachine = (gameId: UUID, gameOwnerId: UUID): FSMStateMachine => {
 	return Machine<FSMContext, FSMStateSchema, FSMEvent>(
@@ -42,128 +51,237 @@ const createMachine = (gameId: UUID, gameOwnerId: UUID): FSMStateMachine => {
 				issues: getIssues(gameId) || hardCodedIssues.issues,
 				gameOwnerId,
 				players: <Array<Player>>[],
+				ephemeral: {},
 			},
-			id: 'game',
-			initial: 'START',
+			id: 'GAME',
+			initial: 'ACTIVE',
 			states: {
-				START: {
-					on: {
-						CREATE_GAME: {
-							target: 'PLAYING',
-							actions: ['createGame'],
+				ACTIVE: {
+					initial: 'START',
+					states: {
+						START: {
+							on: {
+								CREATE_GAME: {
+									target: 'PLAYING',
+									actions: ['createGame'],
+								},
+								PERSIST: {
+									target: '#GAME.PERSISTED',
+								},
+							},
+						},
+						PLAYING: {
+							on: {
+								JOIN_GAME: {
+									target: 'PLAYING',
+									actions: ['addPlayer'],
+								},
+								UPDATE_POINTS: {
+									target: 'PLAYING',
+									actions: ['updatePoints'],
+									cond: isPlayersTurn,
+								},
+								OPEN_ISSUE: {
+									target: 'PLAYING',
+									actions: ['openIssue'],
+									cond: isPlayersTurn,
+								},
+								CLOSE_ISSUE: {
+									target: 'PLAYING',
+									actions: ['closeIssue'],
+									cond: isPlayersTurn,
+								},
+								CONFIRM_MOVE: [
+									{
+										target: 'PLAYING',
+										actions: ['confirmMove'],
+										cond: (context: FSMContext, event: ConfirmMoveEvent) => {
+											return (
+												isPlayersTurn(context, event) && !isOnlyConnectedPlayer(context, event)
+											);
+										},
+									},
+									{
+										target: 'FINISHED',
+										actions: ['confirmMove'],
+										cond: (context: FSMContext, event: ConfirmMoveEvent) => {
+											return (
+												isPlayersTurn(context, event) && isOnlyConnectedPlayer(context, event)
+											);
+										},
+									},
+								],
+								NO_CHANGE: [
+									{
+										target: 'PLAYING',
+										actions: ['noChange'],
+										cond: (context: FSMContext, event: NoChangeClientEvent) => {
+											return (
+												isPlayersTurn(context, event) && !areOtherPlayersDone(context, event)
+											);
+										},
+									},
+									{
+										target: 'FINISHED',
+										actions: ['noChange'],
+										cond: (context: FSMContext, event: NoChangeClientEvent) => {
+											return isPlayersTurn(context, event) && areOtherPlayersDone(context, event);
+										},
+									},
+								],
+								PLAYER_DISCONNECT: {
+									target: 'PLAYING',
+									actions: ['playerDisconnect'],
+								},
+								PERSIST: {
+									target: '#GAME.PERSISTED',
+								},
+							},
+						},
+						FINISHED: {
+							entry: ['scheduleCleanup'],
+							type: 'final',
+						},
+						HISTORY: {
+							type: 'history',
 						},
 					},
 				},
-				PLAYING: {
+				PERSISTED: {
 					on: {
-						JOIN_GAME: {
-							target: 'PLAYING',
-							actions: ['addPlayer'],
-						},
-						UPDATE_POINTS: {
-							target: 'PLAYING',
-							actions: ['updatePoints'],
-							cond: isPlayersTurn,
-						},
-						OPEN_ISSUE: {
-							target: 'PLAYING',
-							actions: ['openIssue'],
-							cond: isPlayersTurn,
-						},
-						CLOSE_ISSUE: {
-							target: 'PLAYING',
-							actions: ['closeIssue'],
-							cond: isPlayersTurn,
-						},
-						CONFIRM_MOVE: [
+						JOIN_GAME: [
 							{
-								target: 'PLAYING',
-								actions: ['confirmMove'],
-								cond: (context: FSMContext, event: ConfirmMoveEvent) => {
-									return isPlayersTurn(context, event) && !isOnlyConnectedPlayer(context, event);
-								},
+								target: 'PERSISTED',
+								actions: ['addPlayer', 'scheduleActivate', 'activateIfAllPlayersConnected'],
+								cond: noConnectedPlayers,
 							},
 							{
-								target: 'FINISHED',
-								actions: ['confirmMove'],
-								cond: (context: FSMContext, event: ConfirmMoveEvent) => {
-									return isPlayersTurn(context, event) && isOnlyConnectedPlayer(context, event);
-								},
+								target: 'PERSISTED',
+								actions: ['addPlayer', 'activateIfAllPlayersConnected'],
+								cond: oneOrMoreConnectedPlayers,
 							},
 						],
-						NO_CHANGE: [
-							{
-								target: 'PLAYING',
-								actions: ['noChange'],
-								cond: (context: FSMContext, event: NoChangeClientEvent) => {
-									return isPlayersTurn(context, event) && !areOtherPlayersDone(context, event);
-								},
-							},
-							{
-								target: 'FINISHED',
-								actions: ['noChange'],
-								cond: (context: FSMContext, event: NoChangeClientEvent) => {
-									return isPlayersTurn(context, event) && areOtherPlayersDone(context, event);
-								},
-							},
-						],
-						PLAYER_DISCONNECT: [
-							{
-								target: 'PLAYING',
-								actions: ['playerDisconnect'],
-							},
-						],
+						ACTIVATE: {
+							target: 'ACTIVE.HISTORY',
+							actions: ['activateGame'],
+						},
 					},
-				},
-				FINISHED: {
-					entry: ['scheduleCleanup'],
-					type: 'final',
 				},
 			},
 		},
 		{
 			actions: {
 				...actions,
+				activateIfAllPlayersConnected,
+				scheduleActivate,
 				scheduleCleanup,
 			},
 		},
 	);
 };
 
-const scheduleCleanup = async (context: FSMContext): Promise<void> => {
+const activateGame = (gameId: UUID) => {
+	const fsmService = FSMServices[gameId];
+	if (fsmService) {
+		fsmService.send(<FSMEvent>{
+			id: <UUID>uuid.v4(),
+			gameId: gameId,
+			type: 'ACTIVATE',
+		});
+	}
+};
+
+const scheduleActivate = async (context: FSMContext, event: FSMEvent): Promise<void> => {
+	const activateDelayMs = 5000;
+	if (context.ephemeral.cancelScheduledActivate) {
+		// scheduler already activated
+		return;
+	}
+	const { gameId } = context;
+	const cancelScheduledActivate = setTimeout(async () => {
+		activateGame(gameId);
+		log.info(
+			`Executed scheduled re-activation, gameId: ${gameId}, event ${event.type} ${event.id} playerId ${event.playerId}`,
+		);
+	}, activateDelayMs);
+	context.ephemeral.cancelScheduledActivate = cancelScheduledActivate;
+	log.info(`Scheduled re-activation, gameId: ${gameId}, event ${event.type} ${event.id} playerId ${event.playerId}`);
+};
+
+const scheduleCleanup = async (context: FSMContext, event: FSMEvent): Promise<void> => {
 	const cleanupDelayHours = 8;
 	const cleanupDelayMs = cleanupDelayHours * 60 * 60 * 1000;
-	await setTimeoutAsync(cleanupDelayMs);
+	setTimeout(async () => {
+		const { gameId } = context;
+		clearIssues(gameId);
+		delete FSMServices[gameId];
+		delete mutexes[gameId];
+		await FSMStateDAO.deleteFSMState(gameId);
+		log.info(
+			`Executed scheduled clean up, gameId: ${gameId}, event ${event.type} ${event.id} playerId ${event.playerId}`,
+		);
+	}, cleanupDelayMs);
+};
+
+const activateIfAllPlayersConnected = (context: FSMContext, event: FSMEvent): void => {
 	const { gameId } = context;
-	clearIssues(gameId);
-	delete FSMServices[gameId];
-	await FSMStateDAO.deleteFSMState(gameId);
-	log.info(`Cleaning up gameId: ${gameId}`);
+	if (allPlayersConnected(context)) {
+		if (context.ephemeral.cancelScheduledActivate) {
+			clearTimeout(context.ephemeral.cancelScheduledActivate);
+			delete context.ephemeral.cancelScheduledActivate;
+			log.info(
+				`Clearing scheduled re-activation, gameId: ${gameId}, event ${event.type} ${event.id} playerId ${event.playerId}`,
+			);
+		}
+		activateGame(gameId);
+		log.info(
+			`All players have reconnected, game activated gameId: ${gameId}, event ${event.type} ${event.id} playerId ${event.playerId}`,
+		);
+	}
+};
+
+const acquireGetFSMServiceMutex = async (gameId: UUID) => {
+	if (mutexes[gameId]) {
+		return await mutexes[gameId].acquire();
+	}
+	const getFSMServiceMutexTimeoutMs = 5000;
+	const mutexWithTimeout = <any>(
+		withTimeout(new Mutex(), getFSMServiceMutexTimeoutMs, new Error('getFSMServiceMutex timeout'))
+	);
+	mutexes[gameId] = mutexWithTimeout;
+	return await mutexes[gameId].acquire();
 };
 
 const getFSMService = async (gameId: UUID, playerId: UUID, allowCreateFSM: boolean): Promise<FSM | undefined> => {
-	if (!FSMServices[gameId]) {
-		const persistedState = await getPersistedState(gameId);
-		if (!persistedState && !allowCreateFSM) {
-			return;
+	const releaseMutex = await acquireGetFSMServiceMutex(gameId);
+	try {
+		if (!FSMServices[gameId]) {
+			const persistedState = await getPersistedState(gameId);
+			if (persistedState || allowCreateFSM) {
+				const gameOwnerId = playerId;
+				const machine = createMachine(gameId, gameOwnerId);
+				const service = interpret(machine).onTransition(persistState);
+				FSMServices[gameId] = service;
+				if (persistedState) {
+					log.info(`Restoring FSMService gameId ${gameId}, playerId ${playerId}`);
+					const state = machine.resolveState(persistedState);
+					service.start(state);
+				} else {
+					service.start();
+				}
+			}
 		}
-		const gameOwnerId = playerId;
-		const machine = createMachine(gameId, gameOwnerId);
-		const service = interpret(machine).onTransition(persistState);
-		if (persistedState) {
-			const state = machine.resolveState(persistedState);
-			service.start(state);
-		} else {
-			service.start();
-		}
-		FSMServices[gameId] = service;
+	} finally {
+		releaseMutex();
+		delete mutexes[gameId];
 	}
 
 	return FSMServices[gameId];
 };
 
 export const processPlayerEvent = async (event: ClientEvent, websocket: FSMWebSocket): Promise<void> => {
-	const { gameId = <UUID>uuid.v4(), playerId = <UUID>uuid.v4(), type } = event;
+	const { gameId = <UUID>uuid.v4(), playerId = <UUID>uuid.v4(), type, id } = event;
+	log.info(`Processing player event ${type},  playerId ${playerId}, eventId ${id}, gameId ${gameId}`);
 	const allowCreateFSM: boolean = type === 'CREATE_GAME';
 	const fsmService = await getFSMService(gameId, playerId, allowCreateFSM);
 	if (fsmService) {
@@ -189,22 +307,27 @@ export const processPlayerDisconnect = (websocket: FSMWebSocket): void => {
 	}
 };
 
+const transitionStateToPersisted = (state: any) => {
+	const { gameId, gameOwnerId } = state.context;
+	const machine = createMachine(gameId, gameOwnerId);
+	return machine.transition(state, 'PERSIST');
+};
+
 const persistState = async (state: any) => {
-	const { context, history, historyValue, value, _event } = state;
-	const contextClone: any = cloneDeep(context);
-	contextClone.players = [];
-	const stateAsJson = safeJsonStringify({
-		_event,
-		value,
-		context: contextClone,
-		history,
-		historyValue,
+	const clonedState = cloneDeep(state);
+	const transitionedState = transitionStateToPersisted(clonedState);
+	transitionedState.context.players.forEach((player: Player) => {
+		player.websocket.readyState = WebSocket.CLOSED;
+		player.ephemeral = {};
 	});
+	transitionedState.context.ephemeral = {};
+	transitionedState.actions = [];
+	const stateAsJson = safeJsonStringify(transitionedState);
 	const now = new Date();
 	await FSMStateDAO.putFSMState({
 		id: state.context.gameId,
 		json: stateAsJson,
-		current_state: <string>state.value,
+		phase: getPhase(state.value),
 		created_date: now,
 		updated_date: now,
 	});

--- a/src/server.ts
+++ b/src/server.ts
@@ -23,7 +23,7 @@ wss.on('connection', (websocket: WebSocket) => {
 	log.info('Client connected');
 	websocket.on('message', (eventJSON: string): void => {
 		const event: ClientEvent = JSON.parse(eventJSON);
-		log.info(`Server received: ${inspect(event)}`);
+		log.debug(`Server received event: ${inspect(event)}`);
 		processPlayerEvent(event, <FSMWebSocket>websocket);
 	});
 

--- a/src/util/logger.ts
+++ b/src/util/logger.ts
@@ -4,9 +4,11 @@ import log4js from 'log4js';
 
 const TRIM_LENGTH = 1024;
 
+const LOG_PATTERN = '%d %p %f{1} %[%m%]';
+
 log4js.configure({
-	appenders: { out: { type: 'stdout', layout: { type: 'basic' } } },
-	categories: { default: { appenders: ['out'], level: 'debug' } },
+	appenders: { out: { type: 'stdout', layout: { type: 'pattern', pattern: LOG_PATTERN } } },
+	categories: { default: { enableCallStack: true, appenders: ['out'], level: 'debug' } },
 });
 
 const getFilename = (url: string): string => {

--- a/src/util/player.ts
+++ b/src/util/player.ts
@@ -9,7 +9,8 @@ export const createPlayer = (context: FSMContext, event: CreateGameClientEvent |
 	const { name, playerId, websocket } = event;
 	const avatarId = getAvailableAvatarId(players, avatarSetId);
 	const status = PlayerStatus.AwaitingMove;
-	return { avatarId, name, playerId, websocket, status };
+	const ephemeral = {};
+	return { avatarId, name, playerId, websocket, status, ephemeral };
 };
 
 export const getPlayerIndex = (players: Array<Player>, playerId: UUID): number => {

--- a/src/util/state.ts
+++ b/src/util/state.ts
@@ -1,0 +1,7 @@
+'use strict';
+
+import { FSMStateValue } from '../types';
+
+export const getPhase = (stateValue: FSMStateValue): string => {
+	return stateValue instanceof Object ? stateValue.ACTIVE : stateValue;
+};

--- a/src/util/websocket.ts
+++ b/src/util/websocket.ts
@@ -11,23 +11,22 @@ export const sendEvent = (websocket: FSMWebSocket, event: Event): void => {
 	if (websocket.readyState === WebSocket.OPEN) {
 		try {
 			websocket.send(JSON.stringify(event));
+			log.debug(`Sending event ${trimString(inspect(event))}`);
 		} catch (error) {
-			log.info(`Failed to send event ${event.id} due to websocket.send() error. [error: ${error}]`);
+			log.info(`Failed to send eventId ${event.id} due to websocket.send() error. [error: ${error}]`);
 		}
 	} else {
-		log.info(`Failed to send event ${event.id} due to websocket not open ${trimString(inspect(event))}`);
+		log.info(`Failed to send eventId ${event.id} due to websocket not open.`);
 	}
 };
 
 export const sendServerEvent = <E extends Event>(player: Player, gameId: UUID, event: E): void => {
 	const { websocket, playerId } = player;
-	log.info(
-		`Sending server event ${event.type} to gameId ${gameId}, playerId ${playerId} ${trimString(inspect(event))}`,
-	);
+	log.info(`Sending server event ${event.type}, playerId ${playerId}, eventId ${event.id} to gameId ${gameId}`);
 	sendEvent(websocket, event);
 };
 
 export const sendClientEvent = (websocket: FSMWebSocket, event: ClientEvent): void => {
-	log.info(`Sending client event ${event.type} ${trimString(inspect(event))}`);
+	log.debug(`Sending client event ${event.type}, eventId ${event.id}`);
 	sendEvent(websocket, event);
 };


### PR DESCRIPTION
• FSM starts in PERSISTED phase after restoring from DB
	• Only action allowed is JOIN_GAME
	• GAME_STATE event contains phase: PERSISTED
	• After everyone rejoining (or after 5 seconds) game transitions to
		PLAYING phase
• New server event GAME_ACTIVATED which is sent once the game
	transitions from PERSISTED to GAME_ACTIVATED
	{
		id: "24bff71d-15c2-4962-b582-63ee11e03a1c"
		phase: "PLAYING"
		type: "GAME_ACTIVATED"
	}
• Fixed race condition when restoring state from DB
	• Introduced mutex for get/create FSMService
• Improved logs
	• Colors
	• Moved event context to DEBUG level
	• Don't output full filepath, only filename