### PR TITLE
Use `build` instead of `postinstall` for compiling

### DIFF
--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
 		"db:rollback": "knex migrate:rollback",
 		"dev": "ts-node src/main.ts --port 8000",
 		"lint": "eslint '**/*.{js,ts}' --fix",
-		"postinstall": "npm run compile && npm run db:migrate",
+		"build": "npm run compile && npm run db:migrate",
 		"pretty": "prettier '**/*.json' --write",
 		"start": "node target/src/main.js --port 8000",
 		"test:watch": "jest --verbose --watch",


### PR DESCRIPTION
Switch from `postinstall` to `build` script to compile typescript and
run db migration. build is executed by heroku. `postinstall` is not
ideal because we don't want to run the db migrate locally after
`npm ci`.